### PR TITLE
Add headers to PHP scripts

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+/*
+# Nombre: dashboard.php
+# Ubicación: admin/dashboard.php
+# Descripción: Panel de control con estadísticas generales
+*/
 require_once '../includes/auth.php';
 
 // Requiere estar logueado (cualquier rol)

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,4 +1,9 @@
 <?php
+/*
+# Nombre: login.php
+# Ubicación: admin/login.php
+# Descripción: Formulario y proceso de inicio de sesión para administradores
+*/
 require_once '../includes/auth.php';
 
 // Si ya está logueado, redirigir al dashboard

--- a/admin/products.php
+++ b/admin/products.php
@@ -1,4 +1,9 @@
 <?php
+/*
+# Nombre: products.php
+# Ubicación: admin/products.php
+# Descripción: Gestión de productos para administradores y vendedores
+*/
 require_once '../includes/auth.php';
 require_once '../includes/upload.php';
 

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,4 +1,9 @@
 <?php
+/*
+# Nombre: users.php
+# Ubicación: admin/users.php
+# Descripción: Administración de usuarios y asignación de roles
+*/
 require_once '../includes/auth.php';
 
 // Solo administradores pueden gestionar usuarios

--- a/config/add_categories.php
+++ b/config/add_categories.php
@@ -1,0 +1,7 @@
+<?php
+/*
+# Nombre: add_categories.php
+# Ubicación: config/add_categories.php
+# Descripción: Script para poblar categorías iniciales en la base de datos
+*/
+

--- a/config/add_categories_migration.php
+++ b/config/add_categories_migration.php
@@ -1,4 +1,9 @@
 <?php
+/*
+# Nombre: add_categories_migration.php
+# Ubicación: config/add_categories_migration.php
+# Descripción: Migración para crear la tabla de categorías y vincular productos
+*/
 /**
  * Migración: crear tabla categories y asignar categorías a productos
  */

--- a/config/db.php
+++ b/config/db.php
@@ -1,4 +1,9 @@
 <?php
+/*
+# Nombre: db.php
+# Ubicación: config/db.php
+# Descripción: Conexión y gestión de la base de datos principal
+*/
 /**
  * Configuración de base de datos centralizada
  * NiceGrowWeb - Sistema de gestión de productos

--- a/config/install.php
+++ b/config/install.php
@@ -1,4 +1,9 @@
 <?php
+/*
+# Nombre: install.php
+# Ubicación: config/install.php
+# Descripción: Instalador inicial de la base de datos y tablas
+*/
 /**
  * Script de instalación de base de datos
  * Ejecutar una sola vez para crear las tablas

--- a/config/update_admin.php
+++ b/config/update_admin.php
@@ -1,4 +1,9 @@
 <?php
+/*
+# Nombre: update_admin.php
+# Ubicación: config/update_admin.php
+# Descripción: Actualiza las credenciales del usuario administrador
+*/
 /**
  * Script para actualizar credenciales de administrador
  * Ejecutar si ya tienes la BD instalada y solo quieres cambiar las credenciales

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,4 +1,9 @@
 <?php
+/*
+# Nombre: auth.php
+# Ubicación: includes/auth.php
+# Descripción: Funciones de autenticación y manejo de sesiones
+*/
 /**
  * Funciones de autenticación y autorización
  * NiceGrowWeb - Sistema de gestión

--- a/includes/upload.php
+++ b/includes/upload.php
@@ -1,4 +1,9 @@
 <?php
+/*
+# Nombre: upload.php
+# Ubicación: includes/upload.php
+# Descripción: Utilidades para subir y validar archivos de imagen
+*/
 /**
  * Funciones para manejo de archivos e imágenes
  * NiceGrowWeb - Sistema de gestión


### PR DESCRIPTION
## Summary
- add standardized comment blocks to admin tools
- document database configuration and install scripts
- annotate authentication utilities and upload helpers
- create header for placeholder `add_categories.php`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855c8c0c93c8330ab324f72442e32db