### PR TITLE
Configurar conexión a BD con variables de entorno

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Sistema de gestión y tienda online para productos de cultivo con panel administ
 ### 2. Configuración
 1. Clona o descarga el proyecto en `c:\xampp\htdocs\NiceGrowWeb`
 2. Inicia Apache y MySQL desde XAMPP
-3. Ejecuta la instalación de BD: `http://localhost/NiceGrowWeb/config/install.php`
-4. Accede a la tienda: `http://localhost/NiceGrowWeb/`
+3. Define las variables de entorno `DB_HOST`, `DB_NAME`, `DB_USER` y `DB_PASS` antes de ejecutar la aplicación. Si no se definen se usarán los valores por defecto (`localhost`, `nicegrow_db`, `root`, "").
+4. Ejecuta la instalación de BD: `http://localhost/NiceGrowWeb/config/install.php`
+5. Accede a la tienda: `http://localhost/NiceGrowWeb/`
 
 ### 3. Panel Administrativo
 - URL: `http://localhost/NiceGrowWeb/admin/login.php`
@@ -133,7 +134,7 @@ deleteImage($fileName)
 
 ### Error de conexión a BD
 - Verificar que MySQL esté corriendo
-- Revisar credenciales en `config/db.php`
+- Revisar que las variables de entorno de la base de datos estén definidas o modifícalas en `config/db.php`
 
 ### Imágenes no se suben
 - Verificar permisos de escritura en `/assets/img/products/`

--- a/config/db.php
+++ b/config/db.php
@@ -1,14 +1,17 @@
 <?php
-/**
- * Configuración de base de datos centralizada
- * NiceGrowWeb - Sistema de gestión de productos
- */
+/*
+# Nombre: db.php
+# Ubicación: config/db.php
+# Descripción: Configuración de base de datos mediante variables de entorno
+*/
 
 // Configuración de base de datos
-define('DB_HOST', 'localhost');
-define('DB_NAME', 'nicegrow_db');
-define('DB_USER', 'root');
-define('DB_PASS', '');
+// Las constantes obtienen su valor desde variables de entorno
+// y utilizan un valor predeterminado si no están definidas
+define('DB_HOST', getenv('DB_HOST') ?: 'localhost');
+define('DB_NAME', getenv('DB_NAME') ?: 'nicegrow_db');
+define('DB_USER', getenv('DB_USER') ?: 'root');
+define('DB_PASS', getenv('DB_PASS') ?: '');
 
 class Database {
     private static $instance = null;


### PR DESCRIPTION
## Resumen
- actualizar cabecera de `config/db.php`
- usar variables de entorno con valores por defecto para la conexión
- documentar las variables de entorno en `README.md`

## Testing
- `php -l config/db.php` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6855c8d841508330bfd2c7bac1393647