### PR TITLE
Implementar claves por variable o formulario

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Sistema de gestión y tienda online para productos de cultivo con panel administ
 ### 2. Configuración
 1. Clona o descarga el proyecto en `c:\xampp\htdocs\NiceGrowWeb`
 2. Inicia Apache y MySQL desde XAMPP
-3. Ejecuta la instalación de BD: `http://localhost/NiceGrowWeb/config/install.php`
+3. Ejecuta la instalación de BD abriendo `http://localhost/NiceGrowWeb/config/install.php`. El instalador solicitará una contraseña para el usuario administrador. También puedes definirla previamente con la variable de entorno `ADMIN_PASSWORD`.
 4. Accede a la tienda: `http://localhost/NiceGrowWeb/`
 
 ### 3. Panel Administrativo
 - URL: `http://localhost/NiceGrowWeb/admin/login.php`
-- Usuario por defecto: `admin`
-- Contraseña por defecto: `admin123`
+- Usuario por defecto: `BioTRaX`
+- Contraseña: la que definiste durante la instalación
 
 ## 📁 Estructura del Proyecto
 

--- a/config/install.php
+++ b/config/install.php
@@ -1,8 +1,8 @@
 <?php
-/**
- * Script de instalación de base de datos
- * Ejecutar una sola vez para crear las tablas
- */
+# Nombre: install.php
+# Ubicación: config/install.php
+# Descripción: Instalador que crea la base de datos y el usuario administrador.
+
 
 echo "<!DOCTYPE html>
 <html lang='es'>
@@ -29,6 +29,21 @@ echo "<!DOCTYPE html>
             <h1>🌱 NiceGrowWeb</h1>
             <p>Instalador de Base de Datos</p>
         </div>";
+
+$adminPassword = getenv('ADMIN_PASSWORD');
+if (!$adminPassword) {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['admin_password'])) {
+        $adminPassword = $_POST['admin_password'];
+    } else {
+        echo "<form method='POST' style='text-align:center; margin:20px;'>";
+        echo "<label>Contrase\u00f1a para el usuario admin:</label>";
+        echo "<input type='password' name='admin_password' required style='margin-left:10px;'>";
+        echo "<button type='submit' class='btn btn-primary'>Instalar</button>";
+        echo "</form>";
+        echo "</div></body></html>";
+        exit;
+    }
+}
 
 // Conectar sin especificar base de datos para poder crearla
 try {
@@ -100,7 +115,7 @@ INSERT IGNORE INTO roles (id, name, description) VALUES
 (2, 'seller', 'Vendedor - CRUD productos propios'),
 (3, 'viewer', 'Solo lectura - Visualización de productos');
 
--- Insertar usuario admin por defecto (usuario: BioTRaX, contraseña: Bio4256)
+-- Insertar usuario admin por defecto (usuario: BioTRaX)
 INSERT IGNORE INTO users (username, email, password, role_id) VALUES
 ('BioTRaX', 'admin@nicegrowweb.com', ?, 1);
 
@@ -112,8 +127,7 @@ INSERT IGNORE INTO products (id, name, price, description) VALUES
 ";
 
 try {
-    // Generar hash para la contraseña del admin
-    $adminPassword = 'Bio4256';
+    // Generar hash para la contraseña del admin proporcionada
     $hashedPassword = password_hash($adminPassword, PASSWORD_DEFAULT);
     
     // Ejecutar las consultas
@@ -134,7 +148,7 @@ try {
     echo "<div class='status success'>✅ Tablas creadas correctamente</div>";
     echo "<div class='status success'>✅ Roles insertados: admin, seller, viewer</div>";
     echo "<div class='status success'>✅ Productos de ejemplo agregados</div>";
-    echo "<div class='status success'>👤 Usuario admin creado: <strong>BioTRaX</strong> / <strong>Bio4256</strong></div>";
+    echo "<div class='status success'>👤 Usuario admin creado: <strong>BioTRaX</strong> / <strong>" . htmlspecialchars($adminPassword) . "</strong></div>";
     
     echo "<div style='text-align: center; margin: 30px 0;'>";
     echo "<h3>🎉 ¡Instalación Completada!</h3>";
@@ -147,7 +161,7 @@ try {
     echo "<h4 style='color: #1976d2; margin-top: 0;'>📋 Credenciales de Administrador:</h4>";
     echo "<ul style='color: #1976d2;'>";
     echo "<li><strong>Usuario:</strong> BioTRaX</li>";
-    echo "<li><strong>Contraseña:</strong> Bio4256</li>";
+    echo "<li><strong>Contrase\u00f1a:</strong> " . htmlspecialchars($adminPassword) . "</li>";
     echo "<li><strong>Rol:</strong> Administrador completo</li>";
     echo "</ul>";
     echo "<p style='color: #666; font-size: 0.9rem;'><em>Puedes cambiar estas credenciales desde el panel de administración.</em></p>";

--- a/config/update_admin.php
+++ b/config/update_admin.php
@@ -1,8 +1,7 @@
 <?php
-/**
- * Script para actualizar credenciales de administrador
- * Ejecutar si ya tienes la BD instalada y solo quieres cambiar las credenciales
- */
+# Nombre: update_admin.php
+# Ubicación: config/update_admin.php
+# Descripción: Actualiza o crea el usuario administrador con nueva contraseña.
 
 echo "<!DOCTYPE html>
 <html lang='es'>
@@ -29,6 +28,21 @@ echo "<!DOCTYPE html>
             <p>Actualizar Credenciales de Administrador</p>
         </div>";
 
+$newPassword = getenv('ADMIN_PASSWORD');
+if (!$newPassword) {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['new_password'])) {
+        $newPassword = $_POST['new_password'];
+    } else {
+        echo "<form method='POST' style='text-align:center; margin:20px;'>";
+        echo "<label>Nueva contrase\u00f1a de administrador:</label>";
+        echo "<input type='password' name='new_password' required style='margin-left:10px;'>";
+        echo "<button type='submit' class='btn btn-primary'>Actualizar</button>";
+        echo "</form>";
+        echo "</div></body></html>";
+        exit;
+    }
+}
+
 try {
     // Conectar a la base de datos
     $pdo = new PDO(
@@ -44,7 +58,6 @@ try {
     
     // Nuevas credenciales
     $newUsername = 'BioTRaX';
-    $newPassword = 'Bio4256';
     $hashedPassword = password_hash($newPassword, PASSWORD_DEFAULT);
     
     // Verificar si ya existe el usuario BioTRaX
@@ -83,7 +96,7 @@ try {
     echo "<h4 style='color: #1976d2; margin-top: 0;'>📋 Nuevas Credenciales:</h4>";
     echo "<ul style='color: #1976d2; text-align: left;'>";
     echo "<li><strong>Usuario:</strong> {$newUsername}</li>";
-    echo "<li><strong>Contraseña:</strong> {$newPassword}</li>";
+    echo "<li><strong>Contrase\u00f1a:</strong> " . htmlspecialchars($newPassword) . "</li>";
     echo "<li><strong>Rol:</strong> Administrador completo</li>";
     echo "</ul>";
     echo "</div>";


### PR DESCRIPTION
## Summary
- pedir contraseña en install.php usando POST o la variable `ADMIN_PASSWORD`
- actualizar script update_admin.php con la misma lógica
- explicar en README cómo definir la contraseña

## Testing
- `php -v` *(falla: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c8e6394483309d3f4e4ec71e2818