### PR TITLE
Implementación de registro y control de roles

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -7,7 +7,7 @@
 require_once '../includes/auth.php';
 
 // Requiere estar logueado (cualquier rol)
-requireRole();
+requireRole([1,2]);
 
 $user = getCurrentUser();
 
@@ -265,7 +265,7 @@ try {
                 </a>
             </li>
             <li class="nav-item mt-3">
-                <a class="nav-link btn-logout" href="login.php?logout=1">
+                <a class="nav-link btn-logout" href="logout.php">
                     <i class="fas fa-sign-out-alt me-2"></i>
                     Cerrar Sesión
                 </a>

--- a/admin/login.php
+++ b/admin/login.php
@@ -167,7 +167,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     </div>
                 <?php endif; ?>
                 
-                <form method="POST" action="">
+                <form method="POST" action="login.php">
                     <div class="form-floating mb-3">
                         <input type="text" class="form-control" id="username" name="username" 
                                placeholder="Usuario" required autocomplete="username">

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,11 @@
+<?php
+/*
+# Nombre: logout.php
+# Ubicación: admin/logout.php
+# Descripción: Cierra la sesión y redirige al login
+*/
+require_once '../includes/auth.php';
+logout();
+header('Location: login.php');
+exit;
+?>

--- a/admin/products.php
+++ b/admin/products.php
@@ -350,7 +350,7 @@ if (isset($_GET['success'])) {
                 </a>
             </li>
             <li class="nav-item mt-3">
-                <a class="nav-link btn-logout" href="login.php?logout=1">
+                <a class="nav-link btn-logout" href="logout.php">
                     <i class="fas fa-sign-out-alt me-2"></i>
                     Cerrar Sesión
                 </a>

--- a/admin/users.php
+++ b/admin/users.php
@@ -344,7 +344,7 @@ if (isset($_GET['success'])) {
                 </a>
             </li>
             <li class="nav-item mt-3">
-                <a class="nav-link btn-logout" href="login.php?logout=1">
+                <a class="nav-link btn-logout" href="logout.php">
                     <i class="fas fa-sign-out-alt me-2"></i>
                     Cerrar Sesión
                 </a>


### PR DESCRIPTION
## Summary
- agregar funciones `register`, `login` y `requireRole` simplificadas
- crear script `logout.php`
- actualizar formulario de login
- proteger dashboard solo para roles 1 y 2
- actualizar enlaces de cierre de sesión

## Testing
- `php` not available, sintaxis no verificada automáticamente

------
https://chatgpt.com/codex/tasks/task_e_6855cedb42e08330a8c1724b484a6b1d