### PR TITLE
Implementar carrito persistente

### DIFF
--- a/carrito.php
+++ b/carrito.php
@@ -1,0 +1,82 @@
+<?php
+/*
+# Nombre: carrito.php
+# Ubicación: carrito.php
+# Descripción: Vista del carrito de compras con modificaci\xC3\xB3n de cantidades
+*/
+require_once __DIR__ . '/includes/cart.php';
+require_once __DIR__ . '/config/db.php';
+
+$pdo = getDB();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['qty'])) {
+        foreach ($_POST['qty'] as $id => $qty) {
+            setQty($pdo, (int)$id, (int)$qty);
+        }
+    }
+    if (isset($_POST['remove'])) {
+        removeFromCart((int)$_POST['remove']);
+    }
+    header('Location: carrito.php');
+    exit;
+}
+
+$items = cartItems();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Carrito</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/estilos.css">
+</head>
+<body>
+<?php include __DIR__ . '/includes/header.php'; ?>
+<div class="container mt-4">
+    <h2>Carrito de compras</h2>
+    <?php if ($items): ?>
+    <form method="post">
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Producto</th>
+                    <th>Cantidad</th>
+                    <th>Subtotal</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php $stmt = $pdo->prepare('SELECT name, price FROM products WHERE id = ?'); ?>
+                <?php foreach ($items as $id => $qty): ?>
+                    <?php
+                        $stmt->execute([$id]);
+                        $p = $stmt->fetch(PDO::FETCH_ASSOC);
+                        if (!$p) continue;
+                        $sub = $p['price'] * $qty;
+                    ?>
+                    <tr>
+                        <td><?= htmlspecialchars($p['name']) ?></td>
+                        <td><input type="number" name="qty[<?= $id ?>]" value="<?= $qty ?>" min="1" class="form-control"/></td>
+                        <td>$<?= number_format($sub, 2) ?></td>
+                        <td>
+                            <button name="remove" value="<?= $id ?>" class="btn btn-danger btn-sm">Eliminar</button>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+        <div class="mb-3">
+            <button type="submit" class="btn btn-primary">Actualizar carrito</button>
+        </div>
+    </form>
+    <h4>Total: $<?= number_format(cartTotal($pdo), 2) ?></h4>
+    <a href="pagar.php" class="btn btn-success mt-3">Proceder al pago</a>
+    <?php else: ?>
+        <p>El carrito est\xC3\xA1 vac\xC3\xADo.</p>
+    <?php endif; ?>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/includes/cart.php
+++ b/includes/cart.php
@@ -1,0 +1,82 @@
+<?php
+/*
+# Nombre: cart.php
+# Ubicación: includes/cart.php
+# Descripción: Funciones para gestionar el carrito de compras almacenado en sesión
+*/
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (!isset($_SESSION['cart'])) {
+    $_SESSION['cart'] = [];
+}
+
+/**
+ * Verificar si el producto existe en la base de datos
+ */
+function cartProductExists(PDO $pdo, int $id): bool {
+    $stmt = $pdo->prepare('SELECT 1 FROM products WHERE id = ?');
+    $stmt->execute([$id]);
+    return (bool) $stmt->fetchColumn();
+}
+
+/**
+ * Agregar un producto al carrito
+ */
+function addToCart(PDO $pdo, int $id, int $qty = 1): void {
+    if ($qty < 1 || !cartProductExists($pdo, $id)) {
+        return;
+    }
+    $_SESSION['cart'][$id] = ($_SESSION['cart'][$id] ?? 0) + $qty;
+}
+
+/**
+ * Eliminar un producto del carrito
+ */
+function removeFromCart(int $id): void {
+    unset($_SESSION['cart'][$id]);
+}
+
+/**
+ * Establecer cantidad exacta de un producto
+ */
+function setQty(PDO $pdo, int $id, int $qty): void {
+    if ($qty < 1) {
+        removeFromCart($id);
+        return;
+    }
+    if (!cartProductExists($pdo, $id)) {
+        return;
+    }
+    $_SESSION['cart'][$id] = $qty;
+}
+
+/**
+ * Obtener items del carrito
+ */
+function cartItems(): array {
+    return $_SESSION['cart'];
+}
+
+/**
+ * Calcular el total del carrito (precio * cantidad)
+ */
+function cartTotal(PDO $pdo): float {
+    $total = 0.0;
+    $stmt = $pdo->prepare('SELECT price FROM products WHERE id = ?');
+    foreach (cartItems() as $id => $qty) {
+        $stmt->execute([$id]);
+        $price = $stmt->fetchColumn();
+        if ($price !== false) {
+            $total += $price * $qty;
+        }
+    }
+    return $total;
+}
+
+/**
+ * Contar la cantidad total de productos en el carrito
+ */
+function cartCount(): int {
+    return array_sum(cartItems());
+}

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,18 @@
+<?php
+/*
+# Nombre: header.php
+# Ubicación: includes/header.php
+# Descripción: Encabezado con barra de navegación y conteo del carrito
+*/
+require_once __DIR__ . '/cart.php';
+?>
+<header>
+    <h1>Nice Grow</h1>
+    <nav>
+        <a href="index.php">Inicio</a>
+        <a href="shop.php">Tienda</a>
+        <a href="carrito.php">🛒 (<?= cartCount() ?>)</a>
+        <a href="#">Contacto</a>
+        <a href="admin/login.php" style="background: rgba(255,255,255,0.2); padding: 5px 10px; border-radius: 5px;">Admin</a>
+    </nav>
+</header>

--- a/pagar.php
+++ b/pagar.php
@@ -7,9 +7,9 @@
 // En un entorno real, aquí se integraría la API de Mercado Pago
 // Para este ejemplo solo se mostrará un mensaje de confirmación.
 
-session_start();
+require_once __DIR__ . '/includes/cart.php';
 // Vaciar el carrito después del pago simulado
-$_SESSION['carrito'] = [];
+$_SESSION['cart'] = [];
 ?>
 <!DOCTYPE html>
 <html lang="es">

--- a/shop.php
+++ b/shop.php
@@ -1,0 +1,63 @@
+<?php
+/*
+# Nombre: shop.php
+# Ubicación: shop.php
+# Descripción: Cat\xC3\xA1logo de productos y adici\xC3\xB3n al carrito reutilizando utilidades
+*/
+require_once __DIR__ . '/includes/cart.php';
+require_once __DIR__ . '/config/db.php';
+
+$pdo = getDB();
+
+// Obtener productos activos
+$stmt = $pdo->query("SELECT id, name, price, description, img, stock FROM products WHERE active = 1 ORDER BY created_at DESC");
+$productos = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+// Agregar al carrito
+if (isset($_GET['agregar'])) {
+    $id = (int) $_GET['agregar'];
+    addToCart($pdo, $id);
+    $redir = 'shop.php';
+    if (!empty($_GET['cat'])) {
+        $redir .= '?cat=' . urlencode($_GET['cat']);
+    }
+    header('Location: ' . $redir . '&added=1');
+    exit;
+}
+
+$added = isset($_GET['added']);
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Tienda</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/estilos.css">
+</head>
+<body>
+<?php include __DIR__ . '/includes/header.php'; ?>
+<div class="container mt-4">
+    <?php if ($added): ?>
+        <div class="alert alert-success">Producto a\xC3\xB1adido</div>
+    <?php endif; ?>
+    <div class="row">
+        <?php foreach ($productos as $p): ?>
+            <div class="col-md-4 mb-3">
+                <div class="card h-100">
+                    <?php if (!empty($p['img'])): ?>
+                        <img src="assets/img/products/<?= htmlspecialchars($p['img']) ?>" class="card-img-top" alt="<?= htmlspecialchars($p['name']) ?>">
+                    <?php endif; ?>
+                    <div class="card-body">
+                        <h5 class="card-title"><?= htmlspecialchars($p['name']) ?></h5>
+                        <p class="card-text">$<?= number_format($p['price'], 2) ?></p>
+                        <a href="shop.php?agregar=<?= $p['id'] ?>" class="btn btn-primary">Agregar</a>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Resumen
- crear utilidades en `includes/cart.php`
- agregar encabezado con conteo del carrito en `includes/header.php`
- nueva página `shop.php` con alerta al agregar productos
- nueva página `carrito.php` para editar cantidades y ver el total
- actualizar `pagar.php` para limpiar el carrito persistente

## Testing
- `php` no está disponible para ejecutar pruebas de sintaxis


------
https://chatgpt.com/codex/tasks/task_e_6855db5584c08330a478f7f8bd5a292f