### PR TITLE
Implementar categorías y corregir sesión

### DIFF
--- a/assets/css/estilos.css
+++ b/assets/css/estilos.css
@@ -33,6 +33,26 @@ body {
             color: #333;
             font-weight: 600;
         }
+
+/* Botones genéricos */
+.btn {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    border-radius: 4px;
+    font-weight: 600;
+}
+.btn-light {
+    background: #ffffff;
+    color: #6A1B9A;
+}
+.btn-light:hover {
+    background: #f0f0f0;
+    color: #6A1B9A;
+}
+.btn-lg {
+    font-size: 1.25rem;
+}
         .hero {
             background: linear-gradient(135deg, #6A1B9A, #388E3C);
             color: white;
@@ -126,6 +146,25 @@ body {
             background: #4A148C;
             color: white;
             text-decoration: none;
+        }
+
+        /* Navegación de categorías */
+        .categorias {
+            display: flex;
+            justify-content: center;
+            gap: 1rem;
+            margin: 1rem 0;
+        }
+        .categorias a {
+            text-decoration: none;
+            color: #6A1B9A;
+            background: #f0f0f0;
+            padding: 0.5rem 1rem;
+            border-radius: 4px;
+        }
+        .categorias a.active {
+            background: #6A1B9A;
+            color: #fff;
         }
 
         /* Mejoras responsivas */

--- a/config/add_categories.php
+++ b/config/add_categories.php
@@ -5,3 +5,24 @@
 # Descripción: Script para poblar categorías iniciales en la base de datos
 */
 
+require_once __DIR__ . '/db.php';
+
+$db = getDB();
+
+$categories = [
+    ['Genética de Cultivo', 'genetica-cultivo'],
+    ['Kits de Cultivo', 'kits-cultivo'],
+    ['Sustratos & Insumos', 'sustratos-insumos'],
+];
+
+$stmt = $db->prepare('INSERT INTO categories (name, slug) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = VALUES(name)');
+foreach ($categories as $cat) {
+    $stmt->execute($cat);
+}
+
+$assign = $db->prepare('UPDATE products SET category_id = (SELECT id FROM categories WHERE slug = ?) WHERE name = ?');
+$assign->execute(['genetica-cultivo', 'Jeringa de esporas']);
+$assign->execute(['genetica-cultivo', 'Micelio en grano']);
+$assign->execute(['genetica-cultivo', 'Semillas de María']);
+
+echo "Categorías insertadas y productos asignados.";

--- a/shop.php
+++ b/shop.php
@@ -25,24 +25,8 @@ if (isset($_GET['agregar'])) {
     exit;
 }
 
+
 $added = isset($_GET['added']);
-
-
-session_start();
-require_once __DIR__ . '/config/db.php';
-
-// Inicializar carrito
-if (!isset($_SESSION['carrito'])) {
-    $_SESSION['carrito'] = [];
-}
-
-// Agregar al carrito
-if (isset($_GET['agregar'])) {
-    $id = (int)$_GET['agregar'];
-    $_SESSION['carrito'][$id] = ($_SESSION['carrito'][$id] ?? 0) + 1;
-    header('Location: shop.php');
-    exit;
-}
 
 // Obtener filtros desde GET
 $cat = $_GET['cat'] ?? 'all';


### PR DESCRIPTION
## Summary
- crear script `add_categories.php` para poblar categorías
- mejorar estilos con botones genéricos y navegación de categorías
- mostrar filtros de categorías en `index.php`
- quitar `session_start` duplicado en `shop.php`

## Testing
- `php -l index.php` *(falló: comando php no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6855e474824c83308479d2e49fb64f29