### PR TITLE
Implementar modo oscuro con botón

### DIFF
--- a/assets/css/estilos.css
+++ b/assets/css/estilos.css
@@ -1,7 +1,7 @@
 /*
 # Nombre: estilos.css
 # Ubicación: assets/css/estilos.css
-# Descripción: Estilos principales para la interfaz de la tienda
+# Descripción: Estilos principales para la interfaz de la tienda y el modo oscuro
 */
 /* Estilos base de la tienda */
 body {
@@ -215,4 +215,42 @@ body {
     padding: 0.5rem 1rem;
     border-radius: 4px;
     cursor: pointer;
+}
+
+/* Botón para cambiar el modo de color */
+.modo-toggle {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background: #6A1B9A;
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    width: 48px;
+    height: 48px;
+    cursor: pointer;
+    z-index: 1000;
+}
+
+/* Modo oscuro por defecto */
+body.dark {
+    background-color: #121212;
+    color: #e0e0e0;
+}
+
+body.dark header {
+    background-color: #1e1e1e;
+}
+
+body.dark .producto,
+body.dark .carrito {
+    background: #1f1f1f;
+}
+
+body.dark footer {
+    background: #2c2c2c;
+}
+
+body.dark nav a {
+    color: #ddd;
 }

--- a/assets/js/funciones.js
+++ b/assets/js/funciones.js
@@ -1,9 +1,34 @@
 /*
 # Nombre: funciones.js
 # Ubicación: assets/js/funciones.js
-# Descripción: Funciones utilitarias para mostrar mensajes en la tienda
+# Descripción: Funciones utilitarias para la tienda y manejo del modo oscuro
 */
 // Funciones básicas para la tienda
 function mostrarMensaje(mensaje) {
     alert(mensaje);
 }
+
+// Configuración de modo oscuro por defecto
+document.addEventListener('DOMContentLoaded', () => {
+    const cuerpo = document.body;
+    const boton = document.getElementById('modoBtn');
+    let modo = localStorage.getItem('modo') || 'oscuro';
+
+    function aplicar() {
+        if (modo === 'oscuro') {
+            cuerpo.classList.add('dark');
+            boton.textContent = '☀';
+        } else {
+            cuerpo.classList.remove('dark');
+            boton.textContent = '🌙';
+        }
+    }
+
+    aplicar();
+
+    boton.addEventListener('click', () => {
+        modo = modo === 'oscuro' ? 'claro' : 'oscuro';
+        localStorage.setItem('modo', modo);
+        aplicar();
+    });
+});

--- a/includes/header.php
+++ b/includes/header.php
@@ -2,7 +2,7 @@
 /*
 # Nombre: header.php
 # Ubicación: includes/header.php
-# Descripción: Encabezado con barra de navegación y conteo del carrito
+# Descripción: Encabezado con barra de navegación, conteo del carrito y botón de modo oscuro
 */
 require_once __DIR__ . '/cart.php';
 ?>
@@ -17,3 +17,5 @@ require_once __DIR__ . '/cart.php';
         <a href="admin/login.php" style="background: rgba(255,255,255,0.2); padding: 5px 10px; border-radius: 5px;">Admin</a>
     </nav>
 </header>
+<button id="modoBtn" class="modo-toggle" aria-label="Cambiar modo"></button>
+<script defer src="assets/js/funciones.js"></script>

--- a/index.php
+++ b/index.php
@@ -156,6 +156,5 @@ function total_carrito($productos, $carrito) {
     <footer>
         © <?= date('Y') ?> Nice Grow. Todos los derechos reservados.
     </footer>
-    <script src="assets/js/funciones.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- actualizar el encabezado para incluir un botón de modo oscuro y cargar el script de funciones
- activar estilo de modo oscuro por defecto con clases CSS
- agregar lógica JS para alternar entre modo oscuro y claro usando localStorage
- eliminar la carga duplicada de `funciones.js` en `index.php`

## Testing
- `php -l includes/header.php` *(falló: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e6cd925c8330820eb683d588b999