### PR TITLE
Agregar gestion de categorias

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -1,0 +1,70 @@
+<?php
+/*
+# Nombre: categories.php
+# Ubicación: admin/categories.php
+# Descripción: Gestión básica de categorías para administradores
+*/
+require_once '../includes/auth.php';
+requireRole([1]);
+
+$user = getCurrentUser();
+$errors = [];
+$success = '';
+
+try {
+    $db = getDB();
+
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        if (!verifyCSRFToken($_POST['csrf_token'] ?? '')) {
+            $errors[] = 'Token CSRF inválido';
+        } else {
+            $name = trim($_POST['name'] ?? '');
+            $slug = trim($_POST['slug'] ?? '');
+            if ($name === '' || $slug === '') {
+                $errors[] = 'Nombre y slug son obligatorios';
+            } else {
+                $stmt = $db->prepare('INSERT INTO categories (name, slug) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = VALUES(name)');
+                $stmt->execute([$name, $slug]);
+                $success = 'Categoría guardada correctamente';
+            }
+        }
+    }
+
+    $stmt = $db->query('SELECT id, name, slug FROM categories ORDER BY name');
+    $categories = $stmt->fetchAll();
+
+} catch (PDOException $e) {
+    $errors[] = 'Error al cargar categorías: ' . $e->getMessage();
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Categorías</title>
+</head>
+<body>
+<h1>Categorías</h1>
+<?php foreach (\$errors as \$msg): ?>
+<p style="color:red"><?= htmlspecialchars(\$msg) ?></p>
+<?php endforeach; ?>
+<?php if (\$success): ?>
+<p style="color:green"><?= htmlspecialchars(\$success) ?></p>
+<?php endif; ?>
+<form method="POST">
+    <input type="hidden" name="csrf_token" value="<?= generateCSRFToken() ?>">
+    <label>Nombre:<input type="text" name="name"></label>
+    <label>Slug:<input type="text" name="slug"></label>
+    <button type="submit">Agregar</button>
+</form>
+<table border="1">
+<thead><tr><th>ID</th><th>Nombre</th><th>Slug</th></tr></thead>
+<tbody>
+<?php foreach (\$categories as \$cat): ?>
+<tr><td><?= \$cat['id'] ?></td><td><?= htmlspecialchars(\$cat['name']) ?></td><td><?= htmlspecialchars(\$cat['slug']) ?></td></tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+</body>
+</html>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -252,6 +252,12 @@ try {
             </li>
             <?php if (isAdmin()): ?>
             <li class="nav-item">
+                <a class="nav-link" href="categories.php">
+                    <i class="fas fa-tags me-2"></i>
+                    Categorías
+                </a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="users.php">
                     <i class="fas fa-users me-2"></i>
                     Usuarios

--- a/admin/products.php
+++ b/admin/products.php
@@ -409,6 +409,12 @@ if (isset($_GET['success'])) {
             </li>
             <?php if (isAdmin()): ?>
             <li class="nav-item">
+                <a class="nav-link" href="categories.php">
+                    <i class="fas fa-tags me-2"></i>
+                    Categorías
+                </a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="users.php">
                     <i class="fas fa-users me-2"></i>
                     Usuarios

--- a/admin/users.php
+++ b/admin/users.php
@@ -332,6 +332,12 @@ if (isset($_GET['success'])) {
                 </a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="categories.php">
+                    <i class="fas fa-tags me-2"></i>
+                    Categorías
+                </a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link active" href="users.php">
                     <i class="fas fa-users me-2"></i>
                     Usuarios

--- a/config/install.php
+++ b/config/install.php
@@ -146,6 +146,10 @@ try {
             }
         }
     }
+
+    // Crear tabla de categorías y valores iniciales
+    require_once __DIR__ . '/install_categories.php';
+    installCategories($pdo);
     
     echo "<div class='status success'>✅ Tablas creadas correctamente</div>";
     echo "<div class='status success'>✅ Roles insertados: admin, seller, viewer</div>";

--- a/config/install_categories.php
+++ b/config/install_categories.php
@@ -1,0 +1,32 @@
+<?php
+/*
+# Nombre: install_categories.php
+# Ubicación: config/install_categories.php
+# Descripción: Crea la tabla de categorías y valores iniciales durante la instalación
+*/
+
+function installCategories(PDO $pdo) {
+    // Crear tabla de categorías
+    $pdo->exec("CREATE TABLE IF NOT EXISTS categories (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(100) NOT NULL,
+        slug VARCHAR(100) UNIQUE NOT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
+
+    // Añadir columna category_id a products si no existe
+    $pdo->exec("ALTER TABLE products
+        ADD COLUMN IF NOT EXISTS category_id INT NULL AFTER user_id,
+        ADD CONSTRAINT IF NOT EXISTS fk_products_categories
+            FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL");
+
+    // Categorías por defecto
+    $stmt = $pdo->prepare('INSERT INTO categories (name, slug) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = VALUES(name)');
+    $cats = [
+        ['Genética de Cultivo', 'genetica-cultivo'],
+        ['Kits de Cultivo', 'kits-cultivo'],
+        ['Sustratos & Insumos', 'sustratos-insumos']
+    ];
+    foreach ($cats as $c) {
+        $stmt->execute($c);
+    }
+}


### PR DESCRIPTION
## Resumen
- crear `config/install_categories.php` para montar categorias por defecto
- llamar a ese script desde `install.php`
- crear pagina basica `admin/categories.php` para gestionar categorias
- agregar enlace a categorias en el menu del panel admin

## Testing
- `php` no esta disponible por lo que no se pudieron ejecutar pruebas de sintaxis.

------
https://chatgpt.com/codex/tasks/task_e_6855e76356d4833095d86dadfe25ba1d