### PR TITLE
Add temporary debug logs for login troubleshooting

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -35,6 +35,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error = 'Por favor, completa todos los campos.';
     } else {
         if (login($username, $password)) {
+            //TODO DEBUG: visualizar mensaje de error previo a la redirección
+            var_dump($error);
             header('Location: dashboard.php');
             exit;
         } else {

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -51,11 +51,26 @@ function register($username, $password, $role_id) {
  */
 function login($username, $password) {
     try {
+        //TODO DEBUG: visualizar el usuario recibido
+        var_dump($username);
+
         $db = getDB();
         $stmt = $db->prepare('SELECT id, password, role_id FROM users WHERE username = ?');
         $stmt->execute([$username]);
         $user = $stmt->fetch();
-        if ($user && password_verify($password, $user["password"])) {
+
+        //TODO DEBUG: confirmar fila obtenida de la base de datos
+        var_dump($user);
+
+        $passwordValid = false;
+        if ($user) {
+            $passwordValid = password_verify($password, $user["password"]);
+        }
+
+        //TODO DEBUG: resultado de password_verify
+        var_dump($passwordValid);
+
+        if ($user && $passwordValid) {
             startSession();
             session_regenerate_id(true);
             $_SESSION['user_id'] = $user['id'];


### PR DESCRIPTION
## Summary
- log received username, DB result and password validation in `login()`
- dump current error before redirecting in `admin/login.php`

## Testing
- `php -l includes/auth.php` *(fails: `php` not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6856f8f0b590833083c76646f2455501