### PR TITLE
Quitar depuración

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -35,8 +35,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error = 'Por favor, completa todos los campos.';
     } else {
         if (login($username, $password)) {
-            //TODO DEBUG: visualizar mensaje de error previo a la redirección
-            var_dump($error);
+            // Mensaje de error previo a la redirección eliminado para desactivar depuración
             header('Location: dashboard.php');
             exit;
         } else {

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -51,24 +51,24 @@ function register($username, $password, $role_id) {
  */
 function login($username, $password) {
     try {
-        //TODO DEBUG: visualizar el usuario recibido
-        var_dump($username);
+        // Nombre de usuario recibido
+        // Se eliminó var_dump para desactivar el modo depuración
 
         $db = getDB();
         $stmt = $db->prepare('SELECT id, password, role_id FROM users WHERE username = ?');
         $stmt->execute([$username]);
         $user = $stmt->fetch();
 
-        //TODO DEBUG: confirmar fila obtenida de la base de datos
-        var_dump($user);
+        // Resultado de la consulta
+        // Se eliminó var_dump para evitar mostrar datos sensibles
 
         $passwordValid = false;
         if ($user) {
             $passwordValid = password_verify($password, $user["password"]);
         }
 
-        //TODO DEBUG: resultado de password_verify
-        var_dump($passwordValid);
+        // Resultado de password_verify
+        // Se eliminó var_dump para desactivar depuración
 
         if ($user && $passwordValid) {
             startSession();


### PR DESCRIPTION
## Summary
- desactivar líneas de depuración en la autenticación y en el login administrativo

## Testing
- `php -l admin/login.php` *(fails: `php` no está instalado)*

------
https://chatgpt.com/codex/tasks/task_e_6856ff7f0b4c8330b1ea19543960a95f