### PR TITLE
Arreglo escapes PHP en categorías

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -46,11 +46,11 @@ try {
 </head>
 <body>
 <h1>Categorías</h1>
-<?php foreach (\$errors as \$msg): ?>
-<p style="color:red"><?= htmlspecialchars(\$msg) ?></p>
+<?php foreach ($errors as $msg): ?>
+<p style="color:red"><?= htmlspecialchars($msg) ?></p>
 <?php endforeach; ?>
-<?php if (\$success): ?>
-<p style="color:green"><?= htmlspecialchars(\$success) ?></p>
+<?php if ($success): ?>
+<p style="color:green"><?= htmlspecialchars($success) ?></p>
 <?php endif; ?>
 <form method="POST">
     <input type="hidden" name="csrf_token" value="<?= generateCSRFToken() ?>">
@@ -61,8 +61,8 @@ try {
 <table border="1">
 <thead><tr><th>ID</th><th>Nombre</th><th>Slug</th></tr></thead>
 <tbody>
-<?php foreach (\$categories as \$cat): ?>
-<tr><td><?= \$cat['id'] ?></td><td><?= htmlspecialchars(\$cat['name']) ?></td><td><?= htmlspecialchars(\$cat['slug']) ?></td></tr>
+<?php foreach ($categories as $cat): ?>
+<tr><td><?= $cat['id'] ?></td><td><?= htmlspecialchars($cat['name']) ?></td><td><?= htmlspecialchars($cat['slug']) ?></td></tr>
 <?php endforeach; ?>
 </tbody>
 </table>


### PR DESCRIPTION
## Resumen
- corregidos seis escapes innecesarios en `admin/categories.php`

## Testing
- `php -l admin/categories.php` *(falló: `php` no está instalado)*

------
https://chatgpt.com/codex/tasks/task_e_685703627cd483308c38f5a889cc3fe8