### PR TITLE
Añadir modo oscuro al panel administrativo

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -49,7 +49,9 @@ try {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Categorías</title>
+<title>Categorías</title>
+<link rel="stylesheet" href="../assets/css/estilos.css">
+<link rel="stylesheet" href="../assets/css/admin-dark.css">
 </head>
 <body>
 <h1>Categorías</h1>
@@ -77,5 +79,7 @@ try {
 <?php endif; ?>
 </tbody>
 </table>
+<button id="modoBtn" class="modo-toggle" aria-label="Cambiar modo"></button>
+<script defer src="../assets/js/funciones.js"></script>
 </body>
 </html>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -51,7 +51,9 @@ try {
     
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    
+    <link rel="stylesheet" href="../assets/css/estilos.css">
+    <link rel="stylesheet" href="../assets/css/admin-dark.css">
+
     <style>
         body {
             background-color: #f8f9fa;
@@ -436,5 +438,7 @@ try {
     
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <button id="modoBtn" class="modo-toggle" aria-label="Cambiar modo"></button>
+    <script defer src="../assets/js/funciones.js"></script>
 </body>
 </html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -57,7 +57,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    
+    <link rel="stylesheet" href="../assets/css/estilos.css">
+    <link rel="stylesheet" href="../assets/css/admin-dark.css">
+
     <style>
         body {
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -212,5 +214,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <button id="modoBtn" class="modo-toggle" aria-label="Cambiar modo"></button>
+    <script defer src="../assets/js/funciones.js"></script>
 </body>
 </html>

--- a/admin/products.php
+++ b/admin/products.php
@@ -275,7 +275,9 @@ if (isset($_GET['success'])) {
     
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    
+    <link rel="stylesheet" href="../assets/css/estilos.css">
+    <link rel="stylesheet" href="../assets/css/admin-dark.css">
+
     <style>
         body {
             background-color: #f8f9fa;
@@ -763,5 +765,7 @@ if (isset($_GET['success'])) {
         });
         <?php endif; ?>
     </script>
+    <button id="modoBtn" class="modo-toggle" aria-label="Cambiar modo"></button>
+    <script defer src="../assets/js/funciones.js"></script>
 </body>
 </html>

--- a/admin/users.php
+++ b/admin/users.php
@@ -201,7 +201,9 @@ if (isset($_GET['success'])) {
     
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    
+    <link rel="stylesheet" href="../assets/css/estilos.css">
+    <link rel="stylesheet" href="../assets/css/admin-dark.css">
+
     <style>
         body {
             background-color: #f8f9fa;
@@ -640,5 +642,7 @@ if (isset($_GET['success'])) {
         });
         <?php endif; ?>
     </script>
+    <button id="modoBtn" class="modo-toggle" aria-label="Cambiar modo"></button>
+    <script defer src="../assets/js/funciones.js"></script>
 </body>
 </html>

--- a/assets/css/admin-dark.css
+++ b/assets/css/admin-dark.css
@@ -1,0 +1,38 @@
+/*
+# Nombre: admin-dark.css
+# Ubicación: assets/css/admin-dark.css
+# Descripción: Estilos para habilitar el modo oscuro en las páginas del panel
+*/
+
+body.dark {
+    background-color: #121212;
+    color: #e0e0e0;
+}
+
+body.dark .sidebar {
+    background: #1e1e1e;
+}
+
+body.dark .main-content {
+    background-color: #121212;
+}
+
+body.dark .card,
+body.dark .stat-card,
+body.dark .brand-header {
+    background: #1f1f1f;
+    color: #e0e0e0;
+}
+
+body.dark .card-header {
+    background-color: #2c2c2c;
+    border-color: #333;
+}
+
+body.dark nav a {
+    color: #cbd5e0;
+}
+
+body.dark .btn-close {
+    filter: invert(1);
+}


### PR DESCRIPTION
## Resumen
- agregar hoja `admin-dark.css` con estilos para modo oscuro
- incluir los nuevos enlaces y botón de cambio en todas las páginas de `admin`

## Testing
- `php` no está disponible en el entorno, por lo que no fue posible ejecutar pruebas de sintaxis

------
https://chatgpt.com/codex/tasks/task_e_68570aec22e08330b955dddff33df458