### PR TITLE
Implementa mejoras dashboard y productos

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -288,6 +288,7 @@ try {
           <!-- Statistics Cards -->
         <div class="row mb-4">
             <div class="col-xl-3 col-md-6 mb-4">
+                <a href="/admin/products.php" class="text-decoration-none">
                 <div class="stat-card">
                     <div class="stat-content">
                         <h6 class="text-uppercase mb-1">Productos</h6>
@@ -297,9 +298,11 @@ try {
                         <i class="fas fa-box"></i>
                     </div>
                 </div>
+                </a>
             </div>
             
             <div class="col-xl-3 col-md-6 mb-4">
+                <a href="/admin/users.php" class="text-decoration-none">
                 <div class="stat-card success">
                     <div class="stat-content">
                         <h6 class="text-uppercase mb-1">Usuarios</h6>
@@ -309,9 +312,11 @@ try {
                         <i class="fas fa-users"></i>
                     </div>
                 </div>
+                </a>
             </div>
             
             <div class="col-xl-3 col-md-6 mb-4">
+                <a href="/admin/products.php?lowstock=1" class="text-decoration-none">
                 <div class="stat-card warning">
                     <div class="stat-content">
                         <h6 class="text-uppercase mb-1">Stock Bajo</h6>
@@ -321,6 +326,7 @@ try {
                         <i class="fas fa-exclamation-triangle"></i>
                     </div>
                 </div>
+                </a>
             </div>
             
             <div class="col-xl-3 col-md-6 mb-4">
@@ -362,7 +368,11 @@ try {
                                     <tbody>
                                         <?php foreach ($recentProducts as $product): ?>
                                         <tr>
-                                            <td class="fw-bold"><?= htmlspecialchars($product['name']) ?></td>
+                                            <td class="fw-bold">
+                                                <a href="/admin/products.php?edit=<?= $product['id'] ?>">
+                                                    <?= htmlspecialchars($product['name']) ?>
+                                                </a>
+                                            </td>
                                             <td class="text-success">$<?= number_format($product['price'], 2) ?></td>
                                             <td>
                                                 <span class="badge bg-<?= $product['stock'] > 10 ? 'success' : ($product['stock'] > 0 ? 'warning' : 'danger') ?>">
@@ -426,7 +436,7 @@ try {
                         <ul class="list-unstyled">
                             <li><strong>Usuario:</strong> <?= htmlspecialchars($user['username']) ?></li>
                             <li><strong>Rol:</strong> <?= htmlspecialchars($user['role_name']) ?></li>
-                            <li><strong>Sesión desde:</strong> <?= date('d/m/Y H:i', $_SESSION['login_time']) ?></li>
+                            <li><strong>Sesión desde:</strong> <?= date('d/m/Y H:i', $_SESSION['login_time'] ?? time()) ?></li>
                         </ul>
                     </div>
                 </div>

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -82,6 +82,8 @@ function login($username, $password) {
             $_SESSION['role_id'] = $user['role_id'];
             $_SESSION['username'] = $user['username'];
             $_SESSION['role_name'] = $user['role_name'] ?? '';
+            // Registrar la hora de inicio de sesión
+            $_SESSION['login_time'] = time();
             return true;
         }
         return false;


### PR DESCRIPTION
## Resumen
- guarda la hora de inicio de sesión
- enlaces en tarjetas del dashboard y nombres de productos
- listado de productos filtra por stock bajo

## Testing
- `php -l includes/auth.php` *(falla: php no disponible)*
- `php -l admin/dashboard.php` *(falla: php no disponible)*

------
https://chatgpt.com/codex/tasks/task_e_68570d0eec508330a93272c0c1a4a552