### PR TITLE
Aplicar colores corporativos al panel admin

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -52,7 +52,7 @@ try {
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="../assets/css/estilos.css">
-    <link rel="stylesheet" href="../assets/css/admin-dark.css">
+    <link rel="stylesheet" href="/NiceGrowWeb/assets/css/admin-dark.css">
 
     <style>
         body {
@@ -218,13 +218,13 @@ try {
 </head>
 <body>
     <!-- Sidebar -->
-    <nav class="sidebar">
+    <nav class="sidebar bg-dark text-white">
         <div class="p-3">
-            <h4 class="text-white mb-0">
+            <h4 class="mb-0">
                 <i class="fas fa-seedling text-success"></i>
-                Nice Grow
+                <span class="brand-text fw-bold text-primary">Nice Grow</span>
             </h4>
-            <small class="text-muted">Panel Admin</small>
+            <small class="text-white-50">Panel Admin</small>
         </div>
         
         <div class="user-info">
@@ -284,14 +284,14 @@ try {
     <!-- Main Content -->
     <main class="main-content">
         <div class="brand-header">
-            <h1 class="h3 mb-0">Dashboard</h1>
-            <p class="text-muted mb-0">Bienvenido al panel de administración</p>
+            <h1 class="h3 mb-0 text-white-50">Dashboard</h1>
+            <p class="text-white-50 mb-0">Bienvenido al panel de administración</p>
         </div>
           <!-- Statistics Cards -->
         <div class="row mb-4">
             <div class="col-xl-3 col-md-6 mb-4">
                 <a href="/admin/products.php" class="text-decoration-none">
-                <div class="stat-card">
+                <div class="stat-card bg-dark text-white">
                     <div class="stat-content">
                         <h6 class="text-uppercase mb-1">Productos</h6>
                         <h2 class="mb-0"><?= $totalProducts ?></h2>
@@ -305,7 +305,7 @@ try {
             
             <div class="col-xl-3 col-md-6 mb-4">
                 <a href="/admin/users.php" class="text-decoration-none">
-                <div class="stat-card success">
+                <div class="stat-card success bg-dark text-white">
                     <div class="stat-content">
                         <h6 class="text-uppercase mb-1">Usuarios</h6>
                         <h2 class="mb-0"><?= $totalUsers ?></h2>
@@ -319,7 +319,7 @@ try {
             
             <div class="col-xl-3 col-md-6 mb-4">
                 <a href="/admin/products.php?lowstock=1" class="text-decoration-none">
-                <div class="stat-card warning">
+                <div class="stat-card warning bg-dark text-white">
                     <div class="stat-content">
                         <h6 class="text-uppercase mb-1">Stock Bajo</h6>
                         <h2 class="mb-0">3</h2>
@@ -332,7 +332,7 @@ try {
             </div>
             
             <div class="col-xl-3 col-md-6 mb-4">
-                <div class="stat-card info">
+                <div class="stat-card info bg-dark text-white">
                     <div class="stat-content">
                         <h6 class="text-uppercase mb-1">Ventas Hoy</h6>
                         <h2 class="mb-0">$0</h2>
@@ -347,7 +347,7 @@ try {
         <!-- Recent Products -->
         <div class="row">
             <div class="col-lg-8">
-                <div class="card">
+            <div class="card">
                     <div class="card-header">
                         <h5 class="mb-0">
                             <i class="fas fa-box me-2"></i>
@@ -357,7 +357,7 @@ try {
                     <div class="card-body">
                         <?php if (!empty($recentProducts)): ?>
                             <div class="table-responsive">
-                                <table class="table table-hover">
+                                <table class="table table-dark table-striped">
                                     <thead class="table-light">
                                         <tr>
                                             <th>Nombre</th>
@@ -405,9 +405,9 @@ try {
             </div>
             
             <div class="col-lg-4">
-                <div class="card">
+                <div class="card border-primary">
                     <div class="card-header">
-                        <h5 class="mb-0">
+                        <h5 class="mb-0 text-primary">
                             <i class="fas fa-info-circle me-2"></i>
                             Acciones Rápidas
                         </h5>
@@ -420,7 +420,7 @@ try {
                             </a>
                             
                             <?php if (isAdmin()): ?>
-                            <a href="users.php" class="btn btn-outline-success">
+                            <a href="users.php" class="btn btn-outline-primary">
                                 <i class="fas fa-user-plus me-2"></i>
                                 Nuevo Usuario
                             </a>

--- a/admin/login.php
+++ b/admin/login.php
@@ -58,7 +58,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="../assets/css/estilos.css">
-    <link rel="stylesheet" href="../assets/css/admin-dark.css">
+    <link rel="stylesheet" href="/NiceGrowWeb/assets/css/admin-dark.css">
 
     <style>
         body {

--- a/admin/products.php
+++ b/admin/products.php
@@ -306,7 +306,7 @@ if (isset($_GET['success'])) {
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="../assets/css/estilos.css">
-    <link rel="stylesheet" href="../assets/css/admin-dark.css">
+    <link rel="stylesheet" href="/NiceGrowWeb/assets/css/admin-dark.css">
 
     <style>
         body {

--- a/admin/users.php
+++ b/admin/users.php
@@ -202,7 +202,7 @@ if (isset($_GET['success'])) {
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="../assets/css/estilos.css">
-    <link rel="stylesheet" href="../assets/css/admin-dark.css">
+    <link rel="stylesheet" href="/NiceGrowWeb/assets/css/admin-dark.css">
 
     <style>
         body {

--- a/assets/css/admin-dark.css
+++ b/assets/css/admin-dark.css
@@ -1,38 +1,20 @@
 /*
 # Nombre: admin-dark.css
 # Ubicación: assets/css/admin-dark.css
-# Descripción: Estilos para habilitar el modo oscuro en las páginas del panel
+# Descripción: Variables y estilos para el modo oscuro del panel de administración
 */
 
-body.dark {
-    background-color: #121212;
-    color: #e0e0e0;
+:root {
+    --bs-body-bg:      #141414;
+    --bs-body-color:   #f1f1f1;
+    --bs-primary:      #6A1B9A;
+    --bs-primary-rgb:  106,27,154;
+    --bs-secondary:    #388E3C;
+    --bs-card-bg:      #1e1e1e;
+    --bs-table-bg:     #1e1e1e;
 }
 
-body.dark .sidebar {
-    background: #1e1e1e;
-}
-
-body.dark .main-content {
-    background-color: #121212;
-}
-
-body.dark .card,
-body.dark .stat-card,
-body.dark .brand-header {
-    background: #1f1f1f;
-    color: #e0e0e0;
-}
-
-body.dark .card-header {
-    background-color: #2c2c2c;
-    border-color: #333;
-}
-
-body.dark nav a {
-    color: #cbd5e0;
-}
-
-body.dark .btn-close {
-    filter: invert(1);
+.nav-link.active {
+    background: var(--bs-primary);
+    color: #fff !important;
 }


### PR DESCRIPTION
## Resumen
- se definen variables de color en `admin-dark.css`
- se ajusta el sidebar del dashboard a fondo oscuro con texto blanco
- se añaden estilos a las tarjetas de estadísticas y tablas del dashboard
- se actualiza la ruta de la hoja de estilos en las páginas del panel

## Testing
- `php -l admin/dashboard.php` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68571220efcc8330b2bd361ce9d81575